### PR TITLE
Expose hit dice count crudely

### DIFF
--- a/src/templates/parts/sheet-header.hbs
+++ b/src/templates/parts/sheet-header.hbs
@@ -51,6 +51,7 @@
     <div class="header-actions">
       <a class="rest short-rest">{{ localize 'DND5E.RestS' }}<i class="fas fa-hourglass-half"></i></a>
       <a class="rest long-rest">{{ localize 'DND5E.RestL' }}<i class="fas fa-hourglass-end"></i></a>
+      <p>Hit Dice: {{data.attributes.hd}}/{{data.details.level}}</p>
     </div>
   </section>
 

--- a/src/templates/parts/sheet-header.hbs
+++ b/src/templates/parts/sheet-header.hbs
@@ -51,7 +51,7 @@
     <div class="header-actions">
       <a class="rest short-rest">{{ localize 'DND5E.RestS' }}<i class="fas fa-hourglass-half"></i></a>
       <a class="rest long-rest">{{ localize 'DND5E.RestL' }}<i class="fas fa-hourglass-end"></i></a>
-      <p>Hit Dice: {{data.attributes.hd}}/{{data.details.level}}</p>
+      <p>{{localize "DND5E.HitDice"}}: {{data.attributes.hd}}/{{data.details.level}}</p>
     </div>
   </section>
 


### PR DESCRIPTION
This simply exposes the number of hit dice available compared to the level of the 5e actor.

<img width="287" alt="Screen Shot 2021-03-08 at 1 34 59 PM" src="https://user-images.githubusercontent.com/3029853/110366094-d5861400-8013-11eb-9fc2-e6b6f299ab85.png">

Resolves #19 