### PR TITLE
Fix V10 deprecation warnings

### DIFF
--- a/src/foundryvtt-compactBeyond5eSheet.ts
+++ b/src/foundryvtt-compactBeyond5eSheet.ts
@@ -3,7 +3,6 @@ import { registerSettings } from './module/settings.js';
 import { getGame, log } from './module/helpers';
 import { preloadTemplates } from './module/preloadTemplates.js';
 import { MODULE_ID, MySettings } from './module/constants.js';
-import ActorSheet5eCharacter from '../../systems/dnd5e/module/actor/sheets/character.js';
 
 Handlebars.registerHelper('cb5es-path', (relativePath: string) => {
   return `modules/${MODULE_ID}/${relativePath}`;
@@ -30,7 +29,7 @@ Handlebars.registerHelper('cb5es-isEmpty', (input: Object | Array<any> | Set<any
   return isObjectEmpty(input);
 });
 
-export class CompactBeyond5eSheet extends ActorSheet5eCharacter {
+export class CompactBeyond5eSheet extends dnd5e.applications.actor.ActorSheet5eCharacter {
   get template() {
     if (!getGame().user?.isGM && this.actor.limited && !getGame().settings.get(MODULE_ID, MySettings.expandedLimited)) {
       return `modules/${MODULE_ID}/templates/character-sheet-ltd.hbs`;

--- a/src/foundryvtt-compactBeyond5eSheet.ts
+++ b/src/foundryvtt-compactBeyond5eSheet.ts
@@ -26,7 +26,7 @@ Handlebars.registerHelper('cb5es-isEmpty', (input: Object | Array<any> | Set<any
   if (input instanceof Set) {
     return input.size < 1;
   }
-  return isObjectEmpty(input);
+  return isEmpty(input);
 });
 
 export class CompactBeyond5eSheet extends dnd5e.applications.actor.ActorSheet5eCharacter {

--- a/src/module.json
+++ b/src/module.json
@@ -8,7 +8,7 @@
 	"author": "Andrew Krigline (akrigline)",
 	"authors": [
 		{
-			"name": "Andrew Krigline (akragline)",
+			"name": "Andrew Krigline (akrigline)",
 			"discord": "Calego#0914",
 			"url": "https://github.com/ElfFriend-DnD",
 			"ko-fi": "https://ko-fi.com/elffriend",

--- a/src/module.json
+++ b/src/module.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/typhonjs-fvtt/validate-manifest/main/schema/strict/module%2B.json",
 	"id": "compact-beyond-5e-sheet",
-	"name": "compact-beyond-5e-sheet",
 	"title": "Compact DnDBeyond 5e Character Sheet",
 	"description": "A compact 5e character sheet with similar layout and functionality to dndbeyond's.",
 	"version": "0.20.0",
@@ -74,7 +73,6 @@
 			"url": "https://raw.githubusercontent.com/ElfFriend-DnD/foundryvtt-compactBeyond5eSheet/master/readme-img/biography.png"
 		}
 	],
-	"minimumCoreVersion": "9",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "10.290"

--- a/src/module.json
+++ b/src/module.json
@@ -1,26 +1,40 @@
 {
 	"$schema": "https://raw.githubusercontent.com/typhonjs-fvtt/validate-manifest/main/schema/strict/module%2B.json",
+	"id": "compact-beyond-5e-sheet",
 	"name": "compact-beyond-5e-sheet",
 	"title": "Compact DnDBeyond 5e Character Sheet",
 	"description": "A compact 5e character sheet with similar layout and functionality to dndbeyond's.",
-	"systems": ["dnd5e"],
 	"version": "0.20.0",
 	"author": "Andrew Krigline (akrigline)",
 	"authors": [
 		{
-			"name": "Andrew Krigline",
+			"name": "Andrew Krigline (akragline)",
 			"discord": "Calego#0914",
 			"url": "https://github.com/ElfFriend-DnD",
+			"ko-fi": "https://ko-fi.com/elffriend",
 			"patreon": "https://www.patreon.com/ElfFriend_DnD"
 		}
 	],
-	"dependencies": [
-		{
-			"name": "character-actions-list-5e",
-			"type": "module",
-			"versionMin": "1.0.0"
-		}
-	],
+	"relationships": {
+		"systems": [
+			{
+				"id": "dnd5e",
+				"type": "system",
+				"compatibility": {
+					"verified": "2.0.3"
+				}
+			}
+		],
+		"requires": [
+			{
+				"id": "character-actions-list-5e",
+				"type": "module",
+				"compatibility": {
+					"verified": "6.0.1"
+				}
+			}
+		]
+	},
 	"esmodules": [
 		"foundryvtt-compactBeyond5eSheet.js"
 	],
@@ -61,8 +75,10 @@
 		}
 	],
 	"minimumCoreVersion": "9",
-	"compatibleCoreVersion": "9",
-	"minimumSystemVersion": "1.4.0",
+	"compatibility": {
+		"minimum": "10",
+		"verified": "10.290"
+	},
 	"bugs": "https://github.com/ElfFriend-DnD/foundryvtt-compactBeyond5eSheet/issues",
 	"changelog": "https://github.com/ElfFriend-DnD/foundryvtt-compactBeyond5eSheet/releases",
 	"download": "https://github.com/ElfFriend-DnD/foundryvtt-compactBeyond5eSheet/releases/download/v0.20.0/module.zip",

--- a/src/templates/character-sheet-ltd.hbs
+++ b/src/templates/character-sheet-ltd.hbs
@@ -18,11 +18,11 @@
       <div class="note-entries">
         <article>
           <h4 class="section-titles biopage">{{ localize "DND5E.Appearance" }}</h4>
-          {{editor content=data.details.appearance target="data.details.appearance" button=true owner=owner editable=editable}}
+          {{editor content=system.details.appearance target="system.details.appearance" button=true owner=owner editable=editable}}
         </article>
         <article class="biography-notes big-bio">
           <h4 class="section-titles">{{ localize "DND5E.Background" }}</h4>
-          {{editor content=data.details.biography.value target="data.details.biography.value" button=true owner=owner editable=editable}}
+          {{editor content=system.details.biography.value target="system.details.biography.value" button=true owner=owner editable=editable}}
         </article>
       </div>
     </div>

--- a/src/templates/character-sheet.hbs
+++ b/src/templates/character-sheet.hbs
@@ -4,14 +4,14 @@
 
   {{!-- Ability Scores --}}
   <ul class="ability-scores ability-score-row">
-    {{#each data.abilities as |ability id|}}
+    {{#each system.abilities as |ability id|}}
     <li class="ability {{#if ability.baseProf}}proficient{{/if}}" data-ability="{{id}}">
       <h4 class="ability-name box-title rollable">{{ability.label}}</h4>
-      <input class="ability-score" name="data.abilities.{{id}}.value" type="text" value="{{ability.value}}"
+      <input class="ability-score" name="system.abilities.{{id}}.value" type="text" value="{{ability.value}}"
         data-dtype="Number" placeholder="10" />
       <div class="ability-modifiers flexrow">
         <span class="ability-mod" title="Modifier">{{numberFormat ability.mod decimals=0 sign=true}}</span>
-        <input type="hidden" name="data.abilities.{{id}}.proficient" value="{{ability.baseProf}}" data-dtype="Number" />
+        <input type="hidden" name="system.abilities.{{id}}.proficient" value="{{ability.baseProf}}" data-dtype="Number" />
         <a class="proficiency-toggle ability-proficiency"
           title="{{ localize 'DND5E.Proficiency' }}">{{{ability.icon}}}</a>
         <span class="ability-save" title="Saving Throw">{{numberFormat ability.save decimals=0 sign=true}}</span>
@@ -24,19 +24,19 @@
     <li class="attribute initiative">
       <h4 class="attribute-name box-title rollable" data-action="rollInitiative">{{ localize "DND5E.Initiative" }}</h4>
       <div class="attribute-value">
-        <span>{{numberFormat data.attributes.init.total decimals=0 sign=true}}</span>
+        <span>{{numberFormat system.attributes.init.total decimals=0 sign=true}}</span>
       </div>
       <footer class="attribute-footer">
         <span>{{ localize "DND5E.Modifier" }}</span>
-        <input name="data.attributes.init.value" type="text" placeholder="0" data-dtype="Number"
-          value="{{numberFormat data.attributes.init.value decimals=0 sign=true}}" />
+        <input name="system.attributes.init.value" type="text" placeholder="0" data-dtype="Number"
+          value="{{numberFormat system.attributes.init.value decimals=0 sign=true}}" />
       </footer>
     </li>
 
     <li class="attribute movement">
-      <h4 class="attribute-name box-title">{{ localize "DND5E.MovementWalk" }} ({{data.attributes.movement.units}})</h4>
+      <h4 class="attribute-name box-title">{{ localize "DND5E.MovementWalk" }} ({{system.attributes.movement.units}})</h4>
       <div class="attribute-value">
-        <span class="movement-primary" title="{{movement.primary}}">{{data.attributes.movement.walk}}</span>
+        <span class="movement-primary" title="{{movement.primary}}">{{system.attributes.movement.walk}}</span>
       </div>
       <footer class="attribute-footer">
         <span class="movement-special" title="{{movement.special}}">{{movement.special}}</span>
@@ -57,21 +57,21 @@
         {{#each resources as |res|}}
         <li class="attribute resource">
           <h4 class="attribute-name box-title">
-            <input name="data.resources.{{res.name}}.label" type="text" value="{{res.label}}"
+            <input name="system.resources.{{res.name}}.label" type="text" value="{{res.label}}"
               placeholder="{{res.placeholder}}" />
           </h4>
           <div class="attribute-value">
             <label class="recharge checkbox">
-              {{ localize "DND5E.AbbreviationSR" }} <input name="data.resources.{{res.name}}.sr" type="checkbox"
+              {{ localize "DND5E.AbbreviationSR" }} <input name="system.resources.{{res.name}}.sr" type="checkbox"
                 {{checked res.sr}} />
             </label>
-            <input name="data.resources.{{res.name}}.value" type="text" value="{{res.value}}" data-dtype="Number"
+            <input name="system.resources.{{res.name}}.value" type="text" value="{{res.value}}" data-dtype="Number"
               placeholder="0" />
             <span class="sep"> / </span>
-            <input name="data.resources.{{res.name}}.max" type="text" value="{{res.max}}" data-dtype="Number"
+            <input name="system.resources.{{res.name}}.max" type="text" value="{{res.max}}" data-dtype="Number"
               placeholder="0" />
             <label class="recharge checkbox">
-              {{ localize "DND5E.AbbreviationLR" }} <input name="data.resources.{{res.name}}.lr" type="checkbox"
+              {{ localize "DND5E.AbbreviationLR" }} <input name="system.resources.{{res.name}}.lr" type="checkbox"
                 {{checked res.lr}} />
             </label>
           </div>
@@ -122,28 +122,28 @@
             <div class="left-notes note-entries flexcol">
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.PersonalityTraits" }}</h4>
-                {{editor content=data.details.trait target="data.details.trait" button=true owner=owner
+                {{editor content=system.details.trait target="system.details.trait" button=true owner=owner
                 editable=editable}}
               </article>
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.Ideals" }}</h4>
-                {{editor content=data.details.ideal target="data.details.ideal" button=true owner=owner
+                {{editor content=system.details.ideal target="system.details.ideal" button=true owner=owner
                 editable=editable}}
               </article>
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.Bonds" }}</h4>
-                {{editor content=data.details.bond target="data.details.bond" button=true owner=owner
+                {{editor content=system.details.bond target="system.details.bond" button=true owner=owner
                 editable=editable}}
               </article>
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.Flaws" }}</h4>
-                {{editor content=data.details.flaw target="data.details.flaw" button=true owner=owner
+                {{editor content=system.details.flaw target="system.details.flaw" button=true owner=owner
                 editable=editable}}
               </article>
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.Alignment" }}</h4>
 
-                <input type="text" name="data.details.alignment" value="{{data.details.alignment}}"
+                <input type="text" name="system.details.alignment" value="{{system.details.alignment}}"
                   placeholder="{{ localize 'DND5E.Alignment' }}" />
               </article>
             </div>
@@ -151,12 +151,12 @@
             <div class="right-notes note-entries flexcol">
               <article>
                 <h4 class="section-titles biopage">{{ localize "DND5E.Appearance" }}</h4>
-                {{editor content=data.details.appearance target="data.details.appearance" button=true owner=owner
+                {{editor content=system.details.appearance target="system.details.appearance" button=true owner=owner
                 editable=editable}}
               </article>
               <article class="biography-notes big-bio">
                 <h4 class="section-titles">{{ localize "DND5E.Background" }}/{{ localize "DND5E.Biography" }}</h4>
-                {{editor content=data.details.biography.value target="data.details.biography.value" button=true
+                {{editor content=system.details.biography.value target="system.details.biography.value" button=true
                 owner=owner editable=editable}}
               </article>
             </div>

--- a/src/templates/parts/actor-features.hbs
+++ b/src/templates/parts/actor-features.hbs
@@ -46,7 +46,7 @@
         <h4>
           {{#if (eq item.type "subclass")}}&rdsh;{{/if}}
           {{item.name}}
-          {{#if item.data.isOriginalClass}} <i class="original-class fas fa-sun"
+          {{#if item.system.isOriginalClass}} <i class="original-class fas fa-sun"
             title="{{localize 'DND5E.ClassOriginal'}}"></i>{{/if}}
         </h4>
         {{else}}
@@ -60,16 +60,16 @@
       <div class="item-detail item-uses">
         {{#if item.isOnCooldown}}
         <a class="item-recharge rollable">{{item.labels.recharge}}</a>
-        {{else if item.data.recharge.value}}
+        {{else if item.system.recharge.value}}
         {{localize "DND5E.Charged"}}
 
         {{else if item.hasUses}}
-        <input type="text" value="{{item.data.uses.value}}" placeholder="0" />/ {{item.data.uses.max}}
+        <input type="text" value="{{item.system.uses.value}}" placeholder="0" />/ {{item.system.uses.max}}
         {{/if}}
       </div>
 
       <div class="item-detail item-action">
-        {{#if item.data.activation.type }}
+        {{#if item.system.activation.type }}
         {{item.labels.activation}}
         {{/if}}
       </div>
@@ -78,7 +78,7 @@
       {{#if section.isClass}}
       {{#unless @root/systemFeatures.subclasses}}
       <div class="item-detail player-class">
-        {{item.data.subclass}}
+        {{item.system.subclass}}
       </div>
       {{/unless}}
       {{#if (eq item.type "class")}}
@@ -95,7 +95,7 @@
           {{/select}}
         </select>
         {{else}}
-        Level {{item.data.levels}}
+        Level {{item.system.levels}}
         {{/if}}
       </div>
       {{/if}}

--- a/src/templates/parts/actor-inventory.hbs
+++ b/src/templates/parts/actor-inventory.hbs
@@ -2,7 +2,7 @@
 
   {{#unless isNPC}}
   <div class="encumberance">
-    {{#with data.attributes.encumbrance}}
+    {{#with system.attributes.encumbrance}}
     <h3><strong>{{localize "CB5ES.WeightCarried"}}:</strong> {{ value }} {{ @root.weightUnit }}</h3>
     <span class="{{#if (gt value max)}}encumbered{{/if}}">
       {{localize "DND5E.Max"}}: {{ max }} {{ @root.weightUnit }}
@@ -18,11 +18,11 @@
       <a class="currency-convert" title="Convert Currency"><i class="fas fa-coins"></i></a>
     </h3>
     <div class="currency-inputs">
-      {{#each data.currency as |v k|}}
+      {{#each system.currency as |v k|}}
       <label class="denomination {{k}}">
         {{#if @root/systemFeatures.currencyLabels}}{{ lookup @root/labels.currencies k }}{{else}}{{k}}{{/if}}
         <div class="dynamic-input">
-          <input type="text" name="data.currency.{{k}}" value="{{v}}" data-dtype="Number" />
+          <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number" />
           <span class="hidden">{{ v }}</span>
         </div>
       </label>
@@ -86,8 +86,8 @@
             aria-label="{{item.name}}"></div>
           <h4>
             {{item.name~}}
-            {{~#if item.isStack}} ({{item.data.quantity}}){{/if}}
-            {{~#if (or item.data.attuned (eq data.attunement 2))}} <i class="fas fa-sun attuned"
+            {{~#if item.isStack}} ({{item.system.quantity}}){{/if}}
+            {{~#if (or item.system.attuned (eq system.attunement 2))}} <i class="fas fa-sun attuned"
               title={{localize "DND5E.Attuned" }}></i>{{/if}}
           </h4>
           {{/if}}
@@ -119,13 +119,13 @@
 
         <div class="item-detail item-uses">
           {{#if item.hasUses }}
-          <input type="text" value="{{item.data.uses.value}}" placeholder="0" />
-          / {{item.data.uses.max}}
+          <input type="text" value="{{item.system.uses.value}}" placeholder="0" />
+          / {{item.system.uses.max}}
           {{/if}}
         </div>
 
         <div class="item-detail item-action">
-          {{#if item.data.activation.type }}
+          {{#if item.system.activation.type }}
           {{item.labels.activation}}
           {{/if}}
         </div>

--- a/src/templates/parts/actor-spellbook.hbs
+++ b/src/templates/parts/actor-spellbook.hbs
@@ -1,14 +1,14 @@
 <div class="spellcasting-ability">
   <div>
     <label>{{localize "DND5E.SpellDC"}} </label>
-    <span>{{data.attributes.spelldc}}</span>
+    <span>{{system.attributes.spelldc}}</span>
   </div>
 
   <div>
     <label>{{localize "DND5E.ItemTypeSpell"}} {{localize "DND5E.Attack"}}</label>
     <span>
-      {{#with (lookup data.abilities data.attributes.spellcasting)}}
-      {{numberFormat (cb5es-add mod ../data.attributes.prof) decimals=0 sign=true}}
+      {{#with (lookup system.abilities system.attributes.spellcasting)}}
+      {{numberFormat (cb5es-add mod ../system.attributes.prof) decimals=0 sign=true}}
       {{/with}}
     </span>
   </div>
@@ -16,15 +16,15 @@
   <div>
     {{#if isNPC}}
     <label>{{localize "DND5E.Level"}}</label>
-    <input class="spellcasting-level" type="text" name="data.details.spellLevel" value="{{data.details.spellLevel}}"
+    <input class="spellcasting-level" type="text" name="system.details.spellLevel" value="{{system.details.spellLevel}}"
       data-dtype="Number" placeholder="0" />
     {{else}}
     <label>{{localize "DND5E.SpellAbility"}}</label>
     {{/if}}
-    <select name="data.attributes.spellcasting" data-type="String">
-      {{#select data.attributes.spellcasting}}
+    <select name="system.attributes.spellcasting" data-type="String">
+      {{#select system.attributes.spellcasting}}
       <option value="">{{localize "DND5E.None"}}</option>
-      {{#each data.abilities as |abl a|}}
+      {{#each system.abilities as |abl a|}}
       <option value="{{a}}">{{abl.label}}</option>
       {{/each}}
       {{/select}}
@@ -55,7 +55,7 @@
 
     <div class="spell-slots">
       {{#if section.usesSlots}}
-      <input type="text" name="data.spells.{{section.prop}}.value" value="{{section.uses}}" placeholder="0"
+      <input type="text" name="system.spells.{{section.prop}}.value" value="{{section.uses}}" placeholder="0"
         data-dtype="Number" />
       <span class="sep"> / </span>
       <span class="spell-max" data-level="{{section.prop}}" data-slots="{{section.slots}}">
@@ -88,14 +88,14 @@
   <ol class="item-list">
     {{#each section.spells as |item i|}}
     <li
-      class="item flexrow {{~#if data.preparation.prepared}} prepared{{/if}}{{#if (eq data.preparation.mode 'always')}} alwaysPrepared{{/if}}"
+      class="item flexrow {{~#if system.preparation.prepared}} prepared{{/if}}{{#if (eq system.preparation.mode 'always')}} alwaysPrepared{{/if}}"
       data-item-id="{{item._id}}">
       <div class="item-name flexrow rollable">
         <div class="item-image" tabindex="0" role="button" aria-label="{{item.name}}"
           style="background-image: url({{item.img}})"></div>
         <h4>{{item.name}}</h4>
-        {{#if item.data.uses.per }}
-        <div class="item-detail spell-uses">Uses {{item.data.uses.value}} / {{item.data.uses.max}}</div>
+        {{#if item.system.uses.per }}
+        <div class="item-detail spell-uses">Uses {{item.system.uses.value}} / {{item.system.uses.max}}</div>
         {{/if}}
       </div>
 
@@ -127,7 +127,7 @@
       <div class="item-controls">
         {{#if section.canPrepare}}
         <a class="item-control item-toggle {{item.toggleClass}}" title="{{item.toggleTitle}}"><i
-            class="{{#if (or data.preparation.prepared (eq data.preparation.mode 'always'))}}fas{{else}}far{{/if}} fa-sun"></i></a>
+            class="{{#if (or system.preparation.prepared (eq system.preparation.mode 'always'))}}fas{{else}}far{{/if}} fa-sun"></i></a>
         {{/if}}
         <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
         <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>

--- a/src/templates/parts/actor-traits.hbs
+++ b/src/templates/parts/actor-traits.hbs
@@ -1,14 +1,14 @@
 <div class="traits">
-  <div class="form-group {{#unless data.attributes.exhaustion}}inactive{{/unless}}">
+  <div class="form-group {{#unless system.attributes.exhaustion}}inactive{{/unless}}">
     <label>{{localize "DND5E.Exhaustion"}}</label>
-    <input type="text" name="data.attributes.exhaustion" data-dtype="Number" placeholder="0"
-      value="{{data.attributes.exhaustion}}" />
+    <input type="text" name="system.attributes.exhaustion" data-dtype="Number" placeholder="0"
+      value="{{system.attributes.exhaustion}}" />
   </div>
 
   <div class="form-group">
     <label>{{localize "DND5E.Size"}}</label>
-    <select class="actor-size" name="data.traits.size">
-      {{#select data.traits.size}}
+    <select class="actor-size" name="system.traits.size">
+      {{#select system.traits.size}}
       {{#each config.actorSizes as |label size|}}
       <option value="{{size}}">{{label}}</option>
       {{/each}}
@@ -29,7 +29,7 @@
   {{/inline}}
 
   {{#unless isVehicle}}
-  <div class="form-group {{#if (and (eq data.traits.senses '') (cb5es-isEmpty senses))}}inactive{{/if}}">
+  <div class="form-group {{#if (and (eq system.traits.senses '') (cb5es-isEmpty senses))}}inactive{{/if}}">
     <label>{{localize "DND5E.Senses"}}</label>
     {{#if senses}}
     <a class="config-button" data-action="senses" title="{{localize 'DND5E.SensesConfig'}}">
@@ -37,75 +37,75 @@
     </a>
     {{> possiblyNoneList list=senses}}
     {{else}}
-    <input type="text" name="data.traits.senses" value="{{data.traits.senses}}"
+    <input type="text" name="system.traits.senses" value="{{system.traits.senses}}"
       placeholder="{{ localize 'DND5E.None' }}" />
     {{/if}}
   </div>
 
-  <div class="form-group {{data.traits.languages.cssClass}}">
+  <div class="form-group {{system.traits.languages.cssClass}}">
     <label>{{localize "DND5E.Languages"}}</label>
-    <a class="trait-selector" data-options="languages" data-target="data.traits.languages">
+    <a class="trait-selector" data-options="languages" data-target="system.traits.languages">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.languages.selected}}
+    {{> possiblyNoneList list=system.traits.languages.selected}}
   </div>
   {{/unless}}
 
-  <div class="form-group {{data.traits.di.cssClass}}">
+  <div class="form-group {{system.traits.di.cssClass}}">
     <label>{{localize "DND5E.DamImm"}}</label>
-    <a class="trait-selector" data-options="damageResistanceTypes" data-target="data.traits.di">
+    <a class="trait-selector" data-options="damageResistanceTypes" data-target="system.traits.di">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.di.selected}}
+    {{> possiblyNoneList list=system.traits.di.selected}}
   </div>
 
-  <div class="form-group {{data.traits.dr.cssClass}}">
+  <div class="form-group {{system.traits.dr.cssClass}}">
     <label>{{localize "DND5E.DamRes"}}</label>
-    <a class="trait-selector" data-options="damageResistanceTypes" data-target="data.traits.dr">
+    <a class="trait-selector" data-options="damageResistanceTypes" data-target="system.traits.dr">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.dr.selected}}
+    {{> possiblyNoneList list=system.traits.dr.selected}}
   </div>
 
-  <div class="form-group {{data.traits.dv.cssClass}}">
+  <div class="form-group {{system.traits.dv.cssClass}}">
     <label>{{localize "DND5E.DamVuln"}}</label>
-    <a class="trait-selector" data-options="damageResistanceTypes" data-target="data.traits.dv">
+    <a class="trait-selector" data-options="damageResistanceTypes" data-target="system.traits.dv">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.dv.selected}}
+    {{> possiblyNoneList list=system.traits.dv.selected}}
   </div>
 
-  <div class="form-group {{data.traits.ci.cssClass}}">
+  <div class="form-group {{system.traits.ci.cssClass}}">
     <label>{{localize "DND5E.ConImm"}}</label>
-    <a class="trait-selector" data-options="conditionTypes" data-target="data.traits.ci">
+    <a class="trait-selector" data-options="conditionTypes" data-target="system.traits.ci">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.ci.selected}}
+    {{> possiblyNoneList list=system.traits.ci.selected}}
   </div>
 
   {{#if isCharacter}}
-  <div class="form-group {{data.traits.weaponProf.cssClass}}">
+  <div class="form-group {{system.traits.weaponProf.cssClass}}">
     <label>{{localize "DND5E.TraitWeaponProf"}}</label>
-    <a class="proficiency-selector" data-type="weapon" data-target="data.traits.weaponProf">
+    <a class="proficiency-selector" data-type="weapon" data-target="system.traits.weaponProf">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.weaponProf.selected}}
+    {{> possiblyNoneList list=system.traits.weaponProf.selected}}
   </div>
 
-  <div class="form-group {{data.traits.armorProf.cssClass}}">
+  <div class="form-group {{system.traits.armorProf.cssClass}}">
     <label>{{localize "DND5E.TraitArmorProf"}}</label>
-    <a class="proficiency-selector" data-type="armor" data-target="data.traits.armorProf">
+    <a class="proficiency-selector" data-type="armor" data-target="system.traits.armorProf">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.armorProf.selected}}
+    {{> possiblyNoneList list=system.traits.armorProf.selected}}
   </div>
 
-  <div class="form-group {{data.traits.toolProf.cssClass}}">
+  <div class="form-group {{system.traits.toolProf.cssClass}}">
     <label>{{localize "DND5E.TraitToolProf"}}</label>
-    <a class="proficiency-selector" data-type="tool" data-target="data.traits.toolProf">
+    <a class="proficiency-selector" data-type="tool" data-target="system.traits.toolProf">
       <i class="fas fa-edit"></i>
     </a>
-    {{> possiblyNoneList list=data.traits.toolProf.selected}}
+    {{> possiblyNoneList list=system.traits.toolProf.selected}}
   </div>
   {{/if}}
 

--- a/src/templates/parts/sheet-header.hbs
+++ b/src/templates/parts/sheet-header.hbs
@@ -13,39 +13,39 @@
     <ul class="inline-summary">
       {{#if disableExperience}}
       <li>
-        <span class="non-editable">{{ localize "DND5E.Level" }} {{data.details.level}}</span>
+        <span class="non-editable">{{ localize "DND5E.Level" }} {{system.details.level}}</span>
       </li>
       {{/if}}
       <li>
-        <input type="text" name="data.details.race" value="{{data.details.race}}"
+        <input type="text" name="system.details.race" value="{{system.details.race}}"
           placeholder="{{ localize 'DND5E.Race' }}" />
-        <span class="hidden">{{#if data.details.race}}{{data.details.race}}{{else}}{{ localize 'DND5E.Race'
+        <span class="hidden">{{#if system.details.race}}{{system.details.race}}{{else}}{{ localize 'DND5E.Race'
           }}{{/if}}</span>
       </li>
       <li><span class="non-editable">{{classLabels}}</span></li>
       <li>
-        <input type="text" name="data.details.background" value="{{data.details.background}}"
+        <input type="text" name="system.details.background" value="{{system.details.background}}"
           placeholder="{{ localize 'DND5E.Background' }}" />
-        <span class="hidden">{{data.details.background}}</span>
+        <span class="hidden">{{system.details.background}}</span>
       </li>
     </ul>
 
     {{#unless disableExperience}}
     <aside class="header-exp flexcol">
       <div class="xpbar">
-        <span class="bar" style="width: {{data.details.xp.pct}}%"></span>
+        <span class="bar" style="width: {{system.details.xp.pct}}%"></span>
       </div>
       <div class="experience flexrow">
 
 
-        <span class="left-label">{{ localize "DND5E.Level" }} {{data.details.level}}</span>
+        <span class="left-label">{{ localize "DND5E.Level" }} {{system.details.level}}</span>
 
-        <input name="data.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number"
+        <input name="system.details.xp.value" type="text" value="{{system.details.xp.value}}" data-dtype="Number"
           placeholder="0" />
         <span class="sep">/</span>
-        <span class="max">{{data.details.xp.max}}</span>
+        <span class="max">{{system.details.xp.max}}</span>
 
-        <span class="right-label">{{ localize "DND5E.Level" }} {{cb5es-add data.details.level 1}}</span>
+        <span class="right-label">{{ localize "DND5E.Level" }} {{cb5es-add system.details.level 1}}</span>
       </div>
     </aside>
     {{/unless}}
@@ -54,7 +54,7 @@
       <a class="rest short-rest">{{ localize 'DND5E.RestS' }}<i class="fas fa-hourglass-half"></i></a>
       <a class="rest long-rest">{{ localize 'DND5E.RestL' }}<i class="fas fa-hourglass-end"></i></a>
       <a class="config-button" data-action="hit-dice" title="{{localize 'DND5E.HitDiceConfig'}}">
-        {{localize "DND5E.HitDice"}}: {{data.attributes.hd}}/{{data.details.level}}
+        {{localize "DND5E.HitDice"}}: {{system.attributes.hd}}/{{system.details.level}}
       </a>
     </div>
   </section>
@@ -68,34 +68,34 @@
         </div>
         <h4>Armor</h4>
         <div class="attribute-value">
-          <span>{{data.attributes.ac.value}}</span>
+          <span>{{system.attributes.ac.value}}</span>
         </div>
         <h4>Class</h4>
         <a class="config-button" data-action="armor" title="{{localize 'DND5E.ArmorConfig'}}"><i
             class="fas fa-cog"></i></a>
       </div>
 
-      {{#if (lt data.attributes.hp.value 1)}}
+      {{#if (lt system.attributes.hp.value 1)}}
       <div class="attribute death-save-attribute">
         <h4 class="attribute-name box-title death-save rollable" data-action="rollDeathSave">
           {{localize 'DND5E.DeathSave'}}</h4>
         <div class="attribute-value multiple">
           <div>
-            <input type="text" name="data.attributes.death.success" data-dtype="Number" placeholder="0"
-              value="{{data.attributes.death.success}}" />
+            <input type="text" name="system.attributes.death.success" data-dtype="Number" placeholder="0"
+              value="{{system.attributes.death.success}}" />
             <label class="attribute-footer">
               <i class="fas fa-check"></i></label>
           </div>
           <div>
-            <input type="text" name="data.attributes.death.failure" data-dtype="Number" placeholder="0"
-              value="{{data.attributes.death.failure}}" />
+            <input type="text" name="system.attributes.death.failure" data-dtype="Number" placeholder="0"
+              value="{{system.attributes.death.failure}}" />
             <label class="attribute-footer">
               <i class="fas fa-times"></i>
             </label>
           </div>
           <div>
-            <small><input type="text" name="data.attributes.hp.value" data-dtype="Number" placeholder="0"
-                value="{{data.attributes.hp.value}}" /></small>
+            <small><input type="text" name="system.attributes.hp.value" data-dtype="Number" placeholder="0"
+                value="{{system.attributes.hp.value}}" /></small>
             <label class="attribute-footer">
               <small>{{localize 'DND5E.ActionHeal'}}</small>
             </label>
@@ -106,17 +106,17 @@
       <div class="attribute health">
         <h4 class="attribute-name box-title">{{ localize "DND5E.HitPoints" }}</h4>
         <div class="attribute-value multiple">
-          <input name="data.attributes.hp.value" type="text" value="{{data.attributes.hp.value}}" data-dtype="Number"
+          <input name="system.attributes.hp.value" type="text" value="{{system.attributes.hp.value}}" data-dtype="Number"
             placeholder="10" />
           <span class="sep"> / </span>
-          <input name="data.attributes.hp.max" type="text" value="{{data.attributes.hp.max}}" data-dtype="Number"
+          <input name="system.attributes.hp.max" type="text" value="{{system.attributes.hp.max}}" data-dtype="Number"
             placeholder="10" />
         </div>
         <footer class="attribute-footer">
-          <input name="data.attributes.hp.temp" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}"
-            data-dtype="Number" value="{{data.attributes.hp.temp}}" />
-          <input name="data.attributes.hp.tempmax" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Max' }}"
-            data-dtype="Number" value="{{data.attributes.hp.tempmax}}" />
+          <input name="system.attributes.hp.temp" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Temp' }}"
+            data-dtype="Number" value="{{system.attributes.hp.temp}}" />
+          <input name="system.attributes.hp.tempmax" type="text" class="temphp" placeholder="+{{ localize 'DND5E.Max' }}"
+            data-dtype="Number" value="{{system.attributes.hp.tempmax}}" />
         </footer>
       </div>
       {{/if}}

--- a/src/templates/parts/sheet-sidebar.hbs
+++ b/src/templates/parts/sheet-sidebar.hbs
@@ -2,7 +2,7 @@
 
   <div class="fancy-value">
     <h4>{{ localize "DND5E.Proficiency" }}</h4>
-    <div>{{#if systemFeatures.profLabel}}{{labels.proficiency}}{{else}}{{numberFormat data.attributes.prof decimals=0
+    <div>{{#if systemFeatures.profLabel}}{{labels.proficiency}}{{else}}{{numberFormat system.attributes.prof decimals=0
       sign=true}}{{/if}}</div>
   </div>
 
@@ -10,18 +10,18 @@
   <div class="fancy-value">
     <h4>{{ localize "DND5E.Inspiration" }}</h4>
     <div>
-      <input type="checkbox" name="data.attributes.inspiration" data-dtype="Boolean" {{checked
-        data.attributes.inspiration}} />
-      <i class="fas fa-sun {{#if data.attributes.inspiration}}active{{/if}}"></i>
+      <input type="checkbox" name="system.attributes.inspiration" data-dtype="Boolean" {{checked
+        system.attributes.inspiration}} />
+      <i class="fas fa-sun {{#if system.attributes.inspiration}}active{{/if}}"></i>
     </div>
   </div>
 
   {{!-- Skills --}}
   <ul class="skills-list">
-    {{#each data.skills as |skill s|}}
+    {{#each system.skills as |skill s|}}
     <li title="{{ localize " DND5E.Passive" }}: {{skill.passive}}"
       class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-skill="{{s}}">
-      <input type="hidden" name="data.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number" />
+      <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.baseValue}}" data-dtype="Number" />
       <a class="proficiency-toggle skill-proficiency" title="{{skill.hover}}">{{{skill.icon}}}</a>
       <span class="skill-ability">{{skill.ability}}</span>
       <div class="skill-name-controls">
@@ -36,7 +36,7 @@
 
   {{#each settings.compact-beyond-5e-sheet.passiveDisplay as |bool s|}}
   {{#if bool}}
-  {{#with (getProperty ../data.skills s)}}
+  {{#with (getProperty ../system.skills s)}}
   <div class="fancy-value">
     <h4>{{ localize "DND5E.Passive" }} {{label}}</h4>
     <div>


### PR DESCRIPTION
# Changes
- Use new data model
- Use `isEmpty` instead of `isObjectEmpty`

Couldn't figure out what exactly is causing the handlebars helper content option deprecation notice, will have to look into that later